### PR TITLE
Encode functions

### DIFF
--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -1,4 +1,20 @@
 
+# based on BSON.jl
+function modpath(x::Module)
+    y = parentmodule(x)
+    result = x == y ? [nameof(x)] : [modpath(y)..., nameof(x)]
+
+    if result[1] == :Main
+        popfirst!(result)
+    end
+
+    return result
+end
+
+# based on BSON.jl
+typepath(x::DataType) = [modpath(x.name.module)..., x.name.name]
+typepathref(x::DataType) = string.(typepath(x))
+
 # Returns a vector of tuples (nm, t),
 # where nm is a Symbol for field name, and t a DataType.
 function nametypetuples(t::DataType)
@@ -10,8 +26,8 @@ function nametypetuples(t::DataType)
     return [ (_fieldnames[i], _fieldtypes[i]) for i in 1:length(_fieldnames) ]
 end
 
-function codegen_serialize(expr, datatype::DataType) :: Expr
-    @nospecialize expr datatype
+function codegen_serialize(datatype::DataType) :: Expr
+    @nospecialize datatype
 
     # "fieldname" => val.val.fieldname
     function field_value_pair_expr(nm::Symbol, @nospecialize(tt::Type{T})) :: Expr where {T}
@@ -23,31 +39,38 @@ function codegen_serialize(expr, datatype::DataType) :: Expr
     field_value_pairs = Expr(:tuple,
         [ field_value_pair_expr(nm, t) for (nm, t) in nametypetuples(datatype) ]...)
 
-    # removes '(' and ')' characters from datatype expression
-    expr_str = replace(replace("$expr", "(" => ""), ")" => "")
+    type_encoded = typepathref(datatype)
 
     quote
         function BSONSerializer.serialize(val::BSONSerializer.Serializable{$datatype})
-            return BSONSerializer.BSON("type" => $expr_str, "args" => BSONSerializer.BSON($field_value_pairs...))
+            return BSONSerializer.BSON("type" => $type_encoded, "args" => BSONSerializer.BSON($field_value_pairs...))
         end
    end
 end
 
-function codegen_deserialize(expr, datatype::DataType) :: Expr
-    @nospecialize expr datatype
+function codegen_deserialize(datatype::DataType) :: Expr
+    @nospecialize datatype
 
     function arg_expr(nm::Symbol, @nospecialize(tt::Type{T})) :: Expr where {T}
         return :(BSONSerializer.decode( args[$("$nm")], $T, m))
     end
 
-    arg_list = Expr(:tuple,
-        [ arg_expr(nm, t) for (nm, t) in nametypetuples(datatype) ]...)
+    # singleton or method
+    if isdefined(datatype, :instance)
+        return quote
+            function BSONSerializer.deserialize(bson::Union{BSONSerializer.BSON, Dict}, ::Type{BSONSerializer.Serializable{$datatype}}, m::Module=Main)
+                ($datatype).instance
+            end
+        end
+    else
+        arg_list = Expr(:tuple,
+            [ arg_expr(nm, t) for (nm, t) in nametypetuples(datatype) ]...)
 
-    expr_str = "$expr"
-    quote
-        function BSONSerializer.deserialize(bson::Union{BSONSerializer.BSON, Dict}, ::Type{BSONSerializer.Serializable{$datatype}}, m::Module=Main)
-            args = bson["args"]
-            ($datatype)($arg_list...)
+        return quote
+            function BSONSerializer.deserialize(bson::Union{BSONSerializer.BSON, Dict}, ::Type{BSONSerializer.Serializable{$datatype}}, m::Module=Main)
+                args = bson["args"]
+                ($datatype)($arg_list...)
+            end
         end
     end
 end
@@ -97,8 +120,8 @@ macro BSONSerializable(expr::Union{Expr, Symbol})
     if is_type_reference(__module__, expr)
         #println("$expr is a type reference.")
         datatype = __module__.eval(expr)
-        expr_serialize_method = codegen_serialize(expr, datatype)
-        expr_deserialize_method = codegen_deserialize(expr, datatype)
+        expr_serialize_method = codegen_serialize(datatype)
+        expr_deserialize_method = codegen_deserialize(datatype)
 
         return quote
             $expr_serialize_method

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -52,13 +52,13 @@ function codegen_deserialize(datatype::DataType) :: Expr
     @nospecialize datatype
 
     function arg_expr(nm::Symbol, @nospecialize(tt::Type{T})) :: Expr where {T}
-        return :(BSONSerializer.decode( args[$("$nm")], $T, m))
+        return :(BSONSerializer.decode( args[$("$nm")], $T))
     end
 
     # singleton or method
     if isdefined(datatype, :instance)
         return quote
-            function BSONSerializer.deserialize(bson::Union{BSONSerializer.BSON, Dict}, ::Type{BSONSerializer.Serializable{$datatype}}, m::Module=Main)
+            function BSONSerializer.deserialize(bson::Union{BSONSerializer.BSON, Dict}, ::Type{BSONSerializer.Serializable{$datatype}})
                 ($datatype).instance
             end
         end
@@ -67,7 +67,7 @@ function codegen_deserialize(datatype::DataType) :: Expr
             [ arg_expr(nm, t) for (nm, t) in nametypetuples(datatype) ]...)
 
         return quote
-            function BSONSerializer.deserialize(bson::Union{BSONSerializer.BSON, Dict}, ::Type{BSONSerializer.Serializable{$datatype}}, m::Module=Main)
+            function BSONSerializer.deserialize(bson::Union{BSONSerializer.BSON, Dict}, ::Type{BSONSerializer.Serializable{$datatype}})
                 args = bson["args"]
                 ($datatype)($arg_list...)
             end
@@ -129,7 +129,7 @@ macro BSONSerializable(expr::Union{Expr, Symbol})
             BSONSerializer.encode_type(::Type{$datatype}) = BSONSerializer.BSON
 
             $expr_deserialize_method
-            BSONSerializer.decode(val::Union{BSONSerializer.BSON, Dict}, ::Type{$datatype}, m::Module) = BSONSerializer.deserialize(val, BSONSerializer.Serializable{$datatype}, m)
+            BSONSerializer.decode(val::Union{BSONSerializer.BSON, Dict}, ::Type{$datatype}) = BSONSerializer.deserialize(val, BSONSerializer.Serializable{$datatype})
         end
 
     elseif isa(expr, Expr) && expr.head == :struct

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -33,9 +33,12 @@ function serialize(val::Serializable{T}) where {T}
     error("Call @BSONSerializable($T) to generate serialize code for $T.")
 end
 
+# based on BSON.jl
+resolve_typepath(fs) = foldl((m, f) -> getfield(m, Symbol(f)), fs; init = Main)
+
 function deserialize(bson::Union{BSON, Dict}, m::Module=Main)
     @assert haskey(bson, "type") && haskey(bson, "args")
-    datatype = m.eval(Meta.parse(bson["type"]))
+    datatype = resolve_typepath(bson["type"])
     @assert isa(datatype, DataType)
     return deserialize(bson, Serializable{datatype}, m)
 end

--- a/src/serialize.jl
+++ b/src/serialize.jl
@@ -11,7 +11,7 @@ Writes a Julia value `val` into `io` using BSON format.
 function serialize end
 
 """
-    deserialize(doc::Union{BSON, Dict}, m::Module=Main)
+    deserialize(doc::Union{BSON, Dict})
 
 Decodes a BSON that was previously encoded using `BSONSerializer.serialize` method
 into a Julia value.
@@ -36,11 +36,11 @@ end
 # based on BSON.jl
 resolve_typepath(fs) = foldl((m, f) -> getfield(m, Symbol(f)), fs; init = Main)
 
-function deserialize(bson::Union{BSON, Dict}, m::Module=Main)
+function deserialize(bson::Union{BSON, Dict})
     @assert haskey(bson, "type") && haskey(bson, "args")
     datatype = resolve_typepath(bson["type"])
     @assert isa(datatype, DataType)
-    return deserialize(bson, Serializable{datatype}, m)
+    return deserialize(bson, Serializable{datatype})
 end
 
 """
@@ -57,8 +57,8 @@ function serialize(io::IO, val::T) where {T}
 	write(io, serialize(val))
 end
 
-function deserialize(io::IO, m::Module=Main)
-	return deserialize(read(io, BSON), m)
+function deserialize(io::IO)
+	return deserialize(read(io, BSON))
 end
 
 @BSONSerializable(Missing)

--- a/test/TestModule.jl
+++ b/test/TestModule.jl
@@ -107,4 +107,12 @@ function Base.:(==)(s1::StructAbsTypes, s2::StructAbsTypes)
     return s1.val == s2.val
 end
 
+struct Lift2
+    op::Function
+    arg1::Number
+    arg2::Number
+end
+
+exec_op(l::Lift2) = l.op(l.arg1, l.arg2)
+
 end # TestModule

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,9 @@ using Mongoc: BSON, BSONObjectId
 using BSONSerializer
 
 include("TestModule.jl")
+
+@test BSONSerializer.typepathref(TestModule.ChildType) == ["TestModule", "ChildType"]
+
 @BSONSerializable(TestModule.ChildType)
 @BSONSerializable(TestModule.FatherType)
 @BSONSerializable(TestModule.ManyDicts)
@@ -49,7 +52,7 @@ end
 
         bson = BSONSerializer.serialize(instance)
         #println(bson)
-        @test bson["type"] == "TestModule.ChildType"
+        @test bson["type"] == ["TestModule", "ChildType"]
         @test isa(bson["args"], Dict)
         args = bson["args"]
         @test args["c1"] == "Hello from ChildType"
@@ -93,13 +96,13 @@ end
 
         bson = BSONSerializer.serialize(father_instance)
         #println(bson)
-        @test bson["type"] == "TestModule.FatherType"
+        @test bson["type"] == ["TestModule", "FatherType"]
         args = bson["args"]
         @test args["f1"] == "Hello from father"
         @test isa(args["f2"], Dict)
         @test args["f3"] == [ 1, 2, 3 ]
         child_dict = args["f2"]
-        @test child_dict["type"] == "TestModule.ChildType"
+        @test child_dict["type"] == ["TestModule", "ChildType"]
         @test isa(child_dict["args"], Dict)
         child_args = child_dict["args"]
         @test child_args["c1"] == "hey"
@@ -196,7 +199,7 @@ end
         instance = TestModule.DateEncodedAsString(Date(2019,12,25))
         bson_with_str = BSON("""
 {
-    "type" : "TestModule.DateEncodedAsString",
+    "type" : ["TestModule", "DateEncodedAsString"],
     "args" : {
         "date" : "2019-12-25"
     }
@@ -215,7 +218,7 @@ end
     @testset "decode Int as Float" begin
         bson = BSON("""
 {
-    "type" : "TestModule.StructFloat",
+    "type" : ["TestModule","StructFloat"],
     "args" : {
         "val" : 10
     }
@@ -243,7 +246,7 @@ end
     @testset "UnionPeriods" begin
         instance = TestModule.UnionPeriods(Dates.Day(1))
         bson = BSONSerializer.serialize(instance)
-        @test bson["type"] == "TestModule.UnionPeriods"
+        @test bson["type"] == ["TestModule","UnionPeriods"]
         val = bson["args"]["val"]
         @test isa(val, Dict)
         @test haskey(val, "type")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ include("TestModule.jl")
 @BSONSerializable(TestModule.Lift2)
 
 function encode_roundtrip(v::T) where {T}
-    BSONSerializer.decode(BSONSerializer.encode(v, T), T, @__MODULE__)
+    BSONSerializer.decode(BSONSerializer.encode(v, T), T)
 end
 
 @testset "encode" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,7 @@ include("TestModule.jl")
 @BSONSerializable(TestModule.StructUInt64)
 @BSONSerializable(TestModule.StructAbsTypes)
 @BSONSerializable(TestModule.UnionPeriods)
+@BSONSerializable(TestModule.Lift2)
 
 function encode_roundtrip(v::T) where {T}
     BSONSerializer.decode(BSONSerializer.encode(v, T), T, @__MODULE__)
@@ -250,7 +251,7 @@ end
         val = bson["args"]["val"]
         @test isa(val, Dict)
         @test haskey(val, "type")
-        @test val["type"] == "Day"
+        @test val["type"] == ["Dates", "Day"]
         @test haskey(val, "value")
         @test val["value"] == 1
         new_instance = BSONSerializer.deserialize(bson)
@@ -294,6 +295,12 @@ end
         new_instance = BSONSerializer.roundtrip(instance)
         @test new_instance == instance
     end
+end
+
+@testset "encode functions" begin
+    instance = TestModule.Lift2(+, 2, 3)
+    new_instance = BSONSerializer.roundtrip(instance)
+    @test TestModule.exec_op(new_instance) == 5
 end
 
 @testset "Usage" begin


### PR DESCRIPTION
still has problems with the corner case of abstract types such as `Array{Int, 2}`.